### PR TITLE
master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "memchr"
@@ -37,42 +37,42 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ name = "basic_usage"
 path = "examples/basic_usage.rs"
 
 [[example]]
+name = "csv_usage"
+path = "examples/csv_usage.rs"
+required-features = ["csv"]
+
+[[example]]
 name = "different_styles"
 path = "examples/different_styles.rs"
 
@@ -34,9 +39,11 @@ path = "examples/group_by_subtotals.rs"
 name = "column_aggregations"
 path = "examples/column_aggregations.rs"
 
+
 [dependencies]
-csv = "1.3.0"
+csv = { version = "1.3.0", optional = true }
 termcolor = "1.4.1"
 
 [features]
-csv = []
+default = ["csv"]
+csv = ["dep:csv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ path = "examples/column_aggregations.rs"
 [dependencies]
 csv = "1.3.0"
 termcolor = "1.4.1"
+
+[features]
+csv = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 mod styles;
 
 use std::io::{self, Write};
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use styles::STYLES;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 #[cfg(test)]
 mod tests;
@@ -249,7 +249,11 @@ impl Table {
     pub fn sort_by_column(&mut self, column_index: usize, ascending: bool) {
         self.rows.sort_by(|a, b| {
             let ord = a[column_index].content.cmp(&b[column_index].content);
-            if ascending { ord } else { ord.reverse() }
+            if ascending {
+                ord
+            } else {
+                ord.reverse()
+            }
         });
     }
 
@@ -303,8 +307,14 @@ impl Table {
         for (i, _column) in self.columns.iter().enumerate() {
             if i == 0 {
                 subtotal_row.push(Cell::new("Subtotal"));
-            } else if group.iter().all(|row| row[i].content.parse::<f64>().is_ok()) {
-                let subtotal: f64 = group.iter().map(|row| row[i].content.parse::<f64>().unwrap()).sum();
+            } else if group
+                .iter()
+                .all(|row| row[i].content.parse::<f64>().is_ok())
+            {
+                let subtotal: f64 = group
+                    .iter()
+                    .map(|row| row[i].content.parse::<f64>().unwrap())
+                    .sum();
                 subtotal_row.push(Cell::new(&subtotal.to_string()));
             } else {
                 subtotal_row.push(Cell::new(""));
@@ -340,9 +350,24 @@ impl Table {
     fn print_headers(&self, writer: &mut dyn WriteColor) -> io::Result<()> {
         for (i, column) in self.columns.iter().enumerate() {
             match column.alignment {
-                Alignment::Left => write!(writer, "{:<width$}", column.header, width = column.width - 1)?,
-                Alignment::Center => write!(writer, "{:^width$}", column.header, width = column.width - 1)?,
-                Alignment::Right => write!(writer, "{:>width$}", column.header, width = column.width - 1)?,
+                Alignment::Left => write!(
+                    writer,
+                    "{:<width$}",
+                    column.header,
+                    width = column.width - 1
+                )?,
+                Alignment::Center => write!(
+                    writer,
+                    "{:^width$}",
+                    column.header,
+                    width = column.width - 1
+                )?,
+                Alignment::Right => write!(
+                    writer,
+                    "{:>width$}",
+                    column.header,
+                    width = column.width - 1
+                )?,
             }
             if i < self.columns.len() - 1 {
                 write!(writer, " ")?;
@@ -372,9 +397,30 @@ impl Table {
                 let padding = " ".repeat(cell.style.padding);
                 let formatted_line = cell.formatted_content();
                 match column.alignment {
-                    Alignment::Left => write!(writer, "{}{:width$}{}", padding, formatted_line, padding, width = column.width - 1)?,
-                    Alignment::Center => write!(writer, "{}{:^width$}{}", padding, formatted_line, padding, width = column.width - 1)?,
-                    Alignment::Right => write!(writer, "{}{:>width$}{}", padding, formatted_line, padding, width = column.width - 1)?,
+                    Alignment::Left => write!(
+                        writer,
+                        "{}{:width$}{}",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width - 1
+                    )?,
+                    Alignment::Center => write!(
+                        writer,
+                        "{}{:^width$}{}",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width - 1
+                    )?,
+                    Alignment::Right => write!(
+                        writer,
+                        "{}{:>width$}{}",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width - 1
+                    )?,
                 }
                 writer.reset()?;
                 write!(writer, " ")?;
@@ -426,9 +472,30 @@ impl Table {
                 let padding = " ".repeat(cell.style.padding);
                 let formatted_line = cell.formatted_content();
                 match column.alignment {
-                    Alignment::Left => write!(writer, " {}{:width$}{} ", padding, formatted_line, padding, width = column.width)?,
-                    Alignment::Center => write!(writer, " {}{:^width$}{} ", padding, formatted_line, padding, width = column.width)?,
-                    Alignment::Right => write!(writer, " {}{:>width$}{} ", padding, formatted_line, padding, width = column.width)?,
+                    Alignment::Left => write!(
+                        writer,
+                        " {}{:width$}{} ",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width
+                    )?,
+                    Alignment::Center => write!(
+                        writer,
+                        " {}{:^width$}{} ",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width
+                    )?,
+                    Alignment::Right => write!(
+                        writer,
+                        " {}{:>width$}{} ",
+                        padding,
+                        formatted_line,
+                        padding,
+                        width = column.width
+                    )?,
                 }
                 writer.reset()?;
             }
@@ -447,11 +514,19 @@ impl Table {
     }
 
     /// Prints the table to the specified writer with styled style.
-    fn print_styled(&self, writer: &mut dyn WriteColor, style: &TableStyleConfig) -> io::Result<()> {
+    fn print_styled(
+        &self,
+        writer: &mut dyn WriteColor,
+        style: &TableStyleConfig,
+    ) -> io::Result<()> {
         self.print_line(writer, &style.top)?;
         self.print_row_styled(
             writer,
-            &self.columns.iter().map(|c| Cell::new(&c.header)).collect::<Vec<_>>(),
+            &self
+                .columns
+                .iter()
+                .map(|c| Cell::new(&c.header))
+                .collect::<Vec<_>>(),
             &style.row,
         )?;
         self.print_line(writer, &style.below_header)?;
@@ -506,52 +581,61 @@ impl Table {
 
     /// Calculates the average of the specified column.
     pub fn average_column(&self, column_index: usize) -> Option<f64> {
-        self.aggregate_column(column_index, |values| values.iter().sum::<f64>() / values.len() as f64)
+        self.aggregate_column(column_index, |values| {
+            values.iter().sum::<f64>() / values.len() as f64
+        })
     }
 
     /// Finds the minimum value in the specified column.
     pub fn min_column(&self, column_index: usize) -> Option<f64> {
-        self.aggregate_column(column_index, |values| *values.iter().min_by(|a, b| a.partial_cmp(b).unwrap()).unwrap())
+        self.aggregate_column(column_index, |values| {
+            *values
+                .iter()
+                .min_by(|a, b| a.partial_cmp(b).unwrap())
+                .unwrap()
+        })
     }
 
     /// Finds the maximum value in the specified column.
     pub fn max_column(&self, column_index: usize) -> Option<f64> {
-        self.aggregate_column(column_index, |values| *values.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap())
+        self.aggregate_column(column_index, |values| {
+            *values
+                .iter()
+                .max_by(|a, b| a.partial_cmp(b).unwrap())
+                .unwrap()
+        })
     }
 }
 
 #[cfg(feature = "csv")]
 mod csv_support {
+    use super::*;
     pub use csv;
-}
 
-#[cfg(feature = "csv")]
-use csv_support::*;
+    impl Table {
+        /// Creates a table from a CSV file.
+        /// The first row of the CSV file is used as the header.
+        pub fn from_csv(path: &str) -> io::Result<Self> {
+            let mut reader = csv::Reader::from_path(path)?;
+            let headers = reader.headers()?;
+            let mut table = Table::new(TableStyle::Simple);
+            for header in headers {
+                table.add_column(header, 10, Alignment::Left);
+            }
+            for result in reader.records() {
+                let record = result?;
+                table.add_row(record.iter().map(|s| Cell::new(s)).collect());
+            }
+            Ok(table)
+        }
 
-#[cfg(feature = "csv")]
-impl Table {
-    /// Creates a table from a CSV file.
-    /// The first row of the CSV file is used as the header.
-    pub fn from_csv(path: &str) -> io::Result<Self> {
-        let mut reader = csv::Reader::from_path(path)?;
-        let headers = reader.headers()?;
-        let mut table = Table::new(TableStyle::Simple);
-        for header in headers {
-            table.add_column(header, 10, Alignment::Left);
+        /// Writes the table to a CSV file.
+        pub fn to_csv(&self, path: &str) -> io::Result<()> {
+            let mut writer = csv::Writer::from_path(path)?;
+            for row in &self.rows {
+                writer.write_record(row.iter().map(|cell| &cell.content))?;
+            }
+            Ok(writer.flush()?)
         }
-        for result in reader.records() {
-            let record = result?;
-            table.add_row(record.iter().map(|s| Cell::new(s)).collect());
-        }
-        Ok(table)
-    }
-
-    /// Writes the table to a CSV file.
-    pub fn to_csv(&self, path: &str) -> io::Result<()> {
-        let mut writer = csv::Writer::from_path(path)?;
-        for row in &self.rows {
-            writer.write_record(row.iter().map(|cell| &cell.content))?;
-        }
-        Ok(writer.flush()?)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,6 +42,7 @@ fn test_add_column() {
     assert!(matches!(table.columns[0].alignment, Alignment::Left));
 }
 
+#[cfg(feature = "csv")]
 #[test]
 fn test_csv_usage() {
     let table = Table::from_csv("examples/data.csv").unwrap();


### PR DESCRIPTION
fixes #6

## what?

make not only `csv` related functionality, but dependency optional (but default) as well
based on [`make_csv_feature_selectable` branch](https://github.com/vschwaberow/tabprinter/tree/make_csv_feature_selectable)

## commits

- **feat: Add CSV feature flag csv dependency #6**
- **fix(csv): make csv a default feature and otherwise optional dependency, tiny refactors, cargo fmt**
